### PR TITLE
Backbone.sync fix to match latest Backbone.js (success/error arguments have changed)

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -66,7 +66,7 @@ _.extend(Store.prototype, {
 
 // Override `Backbone.sync` to use delegate to the model or collection's
 // *localStorage* property, which should be an instance of `Store`.
-Backbone.sync = function(method, model, success, error) {
+Backbone.sync = function(method, model, options) {
 
   var resp;
   var store = model.localStorage || model.collection.localStorage;
@@ -79,8 +79,8 @@ Backbone.sync = function(method, model, success, error) {
   }
 
   if (resp) {
-    success(resp);
+    options.success(resp);
   } else {
-    error("Record not found");
+    options.error("Record not found");
   }
 };


### PR DESCRIPTION
The "success(resp)" call on line 82 in the localStorage adapter was giving me an error.

Looks like Backbone.js was updated and the Model.save arguments no longer matched up with the adapter. 

On line 275 of Backbone.js in the Model.save function is now:

```
  (this.sync || Backbone.sync)(method, this, options);
```

and not:

```
  (this.sync || Backbone.sync)(method, this, success, error);
```

so I made the change accordingly to the localStorage adapter.
