### PR TITLE
Added backwards-compatibility with Backbone.sync <= 0.3.3

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -51,7 +51,7 @@ _.extend(Store.prototype, {
 
   // Return the array of all models currently in storage.
   findAll: function() {
-    return _.map(this.records, function(id){return JSON.parse(localStorage.getItem(this.name+"-"+id))}, this);
+    return _.map(this.records, function(id){return JSON.parse(localStorage.getItem(this.name+"-"+id));}, this);
   },
 
   // Delete a model from `this.data`, returning it.
@@ -66,7 +66,15 @@ _.extend(Store.prototype, {
 
 // Override `Backbone.sync` to use delegate to the model or collection's
 // *localStorage* property, which should be an instance of `Store`.
-Backbone.sync = function(method, model, options) {
+Backbone.sync = function(method, model, options, error) {
+
+  // Backwards compatibility with Backbone <= 0.3.3
+  if (typeof options == 'function') {
+    options = {
+      success: options,
+      error: error
+    };
+  }
 
   var resp;
   var store = model.localStorage || model.collection.localStorage;


### PR DESCRIPTION
Change to detect older args to Backbone.sync as discussed at https://github.com/jeromegn/Backbone.localStorage/commit/de5d30a7b1e74c7dce218b9055aae8f33b13b2dd

Checked that this works with Backbone 0.3.3.

I'm not sure how you like to generate the minified version, so this change is only to the non-minified source.
