### PR TITLE
Allow users to provide a 'complete' callback

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -98,4 +98,5 @@ Backbone.sync = function(method, model, options, error) {
   } else {
     options.error("Record not found");
   }
+  if (options.complete) options.complete(resp);
 };


### PR DESCRIPTION
Check if a 'complete' callback is available and if so, execute it after the succes / error callback has been run.

This can DRY up some code and it resembles the standard Backbone.sync a bit closer.
