### PR TITLE
Default to the original Backbone sync method when no localStorage is available

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -84,12 +84,6 @@ _.extend(Backbone.LocalStorage.prototype, {
 Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(method, model, options, error) {
   var store = model.localStorage || model.collection.localStorage;
 
-  // if there's no localStorage property, we can assume that we want to use the default Backbone sync method.
-  if(!store) {
-    Backbone.ajaxSync(method, model, options, error);
-    return;
-  }
-
   // Backwards compatibility with Backbone <= 0.3.3
   if (typeof options == 'function') {
     options = {
@@ -114,9 +108,21 @@ Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(m
   }
 };
 
-// Override 'Backbone.sync' to default to localSync, 
-// the original 'Backbone.sync' is still available in 'Backbone.ajaxSync'
 Backbone.ajaxSync = Backbone.sync;
-Backbone.sync = Backbone.LocalStorage.sync;
+
+Backbone.getSyncMethod = function(model) {
+	if(model.localStorage || (model.collection && model.collection.localStorage))
+	{
+		return Backbone.localSync;
+	}
+
+	return Backbone.ajaxSync;
+};
+
+// Override 'Backbone.sync' to default to localSync,
+// the original 'Backbone.sync' is still available in 'Backbone.ajaxSync'
+Backbone.sync = function(method, model, options, error) {
+	Backbone.getSyncMethod(model).apply(this, [method, model, options, error]);
+};
 
 })();

--- a/tests/test.js
+++ b/tests/test.js
@@ -142,5 +142,21 @@ $(document).ready(function() {
 		book.destroy()
 		equals(Book.prototype.localStorage.findAll().length, 0, 'book removed');
 	});
-	
+
+	test("Book should use local sync", function()
+	{
+		var method = Backbone.getSyncMethod(book);
+		equals(method, Backbone.localSync);
+	});
+
+	var MyRemoteModel = Backbone.Model.extend();
+
+	var remoteModel = new MyRemoteModel();
+
+	test("remoteModel should use ajax sync", function()
+	{
+		var method = Backbone.getSyncMethod(remoteModel);
+		equals(method, Backbone.ajaxSync);
+	});
+
 });


### PR DESCRIPTION
Models/Collections who are unaware of LocalStorage shouldn't use the localSync method.

I haven't minified these changes.
