### PR TITLE
Update backbone.localStorage.js

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -125,7 +125,7 @@ Backbone.ajaxSync = Backbone.sync;
 Backbone.getSyncMethod = function(model) {
 	if(model.localStorage || (model.collection && model.collection.localStorage))
 	{
-		return Backbone.localSync;
+		return Backbone.LocalStorage.sync;
 	}
 
 	return Backbone.ajaxSync;


### PR DESCRIPTION
Updated/removed reference to deprecated method. Using "Backbone.LocalStorage.sync" instead of the deprecated "Backbone.localSync". 
