### PR TITLE
FIX: correctly fetch() content for Backbone.Model Objects

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -103,7 +103,12 @@ Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(m
   var resp, syncDfd = $.Deferred && $.Deferred(); //If $ is having Deferred - use it. 
 
   switch (method) {
-    case "read":    resp = model.id != undefined ? store.find(model) : store.findAll(); break;
+    case "read":
+        resp = model.id != undefined ? store.find(model) : store.findAll();
+        if(resp && resp.length >= 1 && (model instanceof Backbone.Model) ){
+            resp = resp[0];
+        }
+        break;
     case "create":  resp = store.create(model);                            break;
     case "update":  resp = store.update(model);                            break;
     case "delete":  resp = store.destroy(model);                           break;


### PR DESCRIPTION
This lib did not correctly fetch()/ 'read'/'GET'
from local storage for Backbone.Model objects after page refresh.

It does work in the tests however because the tests
do not refresh the page and load once again from localStorage.
The tests rely on the _in memory_ version of the object to return the correct result.

In my personal test this worked for Backbone.Model, but I did
not test Backbone.Collection Objects.
