### PR TITLE
Fix for when developer has specified in backbone which jQuery version to use by setting Backbone.$

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -133,7 +133,7 @@ _.extend(Backbone.LocalStorage.prototype, {
 Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(method, model, options) {
   var store = model.localStorage || model.collection.localStorage;
 
-  var resp, errorMessage, syncDfd = $.Deferred && $.Deferred(); //If $ is having Deferred - use it.
+  var resp, errorMessage, syncDfd = Backbone.$.Deferred && Backbone.$.Deferred(); //If $ is having Deferred - use it.
 
   try {
 


### PR DESCRIPTION
Makes sure the correct(expected) version of jquery is always used.
