### PR TITLE
Replaced DOMException.QUOTA_EXCEEDED_ERR with its value

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -160,7 +160,7 @@ Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(m
     }
 
   } catch(error) {
-    if (error.code === DOMException.QUOTA_EXCEEDED_ERR && store._storageSize() === 0)
+    if (error.code === 22 && store._storageSize() === 0)
       errorMessage = "Private browsing is unsupported";
     else
       errorMessage = error.message;


### PR DESCRIPTION
Replaced the constant DOMException.QUOTA_EXCEEDED_ERR with its value in order to
support IE8, since DOMException is not defined in IE8 and below.

An alternative would be to check if DOMException is defined and set it if not.

Would close issue https://github.com/jeromegn/Backbone.localStorage/issues/93
