### PR TITLE
Detect if require object available on root

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -5,7 +5,7 @@
  * https://github.com/jeromegn/Backbone.localStorage
  */
 (function (root, factory) {
-   if (typeof exports === 'object' && typeof root.require !== "undefined") {
+   if (typeof exports === 'object' && root.require) {
      module.exports = factory(require("underscore"), require("backbone"));
    } else if (typeof define === "function" && define.amd) {
       // AMD. Register as an anonymous module.


### PR DESCRIPTION
We are using a non RequireJS build system that uses the `exports` variable. Backbone.LocalStorage looks for exports, but then assumes require is available if it sees `exports`. This breaks our application. Instead do a more granular lookup to see if exports is available AND `require` is available on the root object.
