### PR TITLE
Abstracted serialization of models out so that it could be replaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 spec/localStorage_commonjs_spec.bundled.js
 node_modules
 \.DS_Store
+.idea


### PR DESCRIPTION
Hello,

I wanted to be able to inject logic for the serialization of models bound for localStorage for purposes of encryption. I acheived this by allowing for a "seralizer" object to be injected upon creation of the Backbone.LocalStorage object.

I hope you may find this change useful..

Thanks for the great plugin by the way!

James
