### PR TITLE
Remove DOM library hard dependency

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -142,7 +142,9 @@ _.extend(Backbone.LocalStorage.prototype, {
 Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(method, model, options) {
   var store = model.localStorage || model.collection.localStorage;
 
-  var resp, errorMessage, syncDfd = Backbone.$.Deferred && Backbone.$.Deferred(); //If $ is having Deferred - use it.
+  var resp, errorMessage,
+    // If $ and $ is having Deferred - use it.
+    syncDfd = Backbone.$ && Backbone.$.Deferred && Backbone.$.Deferred();
 
   try {
 


### PR DESCRIPTION
Backbone only has a dependency on a DOM library if you intend to use
_Backbone.View_. If you don't include a DOM library, `Backbone.$` will be
`undefined`.

Since Backbone.localStorage doesn't have a hard dependency on
_jQuery.Deferred_, it should check for the existence of `Backbone.$`
before accessing one of its members otherwise this plugin raises
`Uncaught ReferenceError: $ is not defined`.

This makes it possible to use Backbone.localStorage with Backbone and
an alternative to _Backbone.View_.
