### PR TITLE
Put "<script>" in backticks for compatibility with Docco

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -14,7 +14,7 @@
         return factory(_ || root._, Backbone || root.Backbone);
       });
    } else {
-      // RequireJS isn't being used. Assume underscore and backbone are loaded in <script> tags
+      // RequireJS isn't being used. Assume underscore and backbone are loaded in `<script>` tags
       factory(_, Backbone);
    }
 }(this, function(_, Backbone) {


### PR DESCRIPTION
Running [Docco](https://github.com/jashkenas/docco) against `backbone.localStorage.js` produces an incomplete docs page that ends just before the "&lt;script&gt;" in this file. It seems Docco thinks the file ends there or something. Putting "&lt;script&gt;" in backticks fixes the issue.
