### PR TITLE
Removed call to jsonData that was not removed from before.

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -108,7 +108,6 @@ extend(Backbone.LocalStorage.prototype, {
     for (var i = 0, id, data; i < this.records.length; i++) {
       id = this.records[i];
       data = this.serializer.deserialize(this.localStorage().getItem(this.name+"-"+id));
-      data = this.jsonData(this.localStorage().getItem(this.name+"-"+id));
       if (data != null) result.push(data);
     }
     return result;


### PR DESCRIPTION
Looking at 17c562cc4751ce3f67c4055987a4b92beb936b1f:backbone.localStorage.js, I see that jsonData was defined, but the latest version does not. Removing extra call to removed jsonData.
