### PR TITLE
Removed call to dead jsonData function.

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -108,7 +108,6 @@ extend(Backbone.LocalStorage.prototype, {
     for (var i = 0, id, data; i < this.records.length; i++) {
       id = this.records[i];
       data = this.serializer.deserialize(this.localStorage().getItem(this.name+"-"+id));
-      data = this.jsonData(this.localStorage().getItem(this.name+"-"+id));
       if (data != null) result.push(data);
     }
     return result;


### PR DESCRIPTION
This is my first pull request - been banging my head on the first exercise in a backbone book (todo mvc), and I finally traced the problem to the version of Backbone.localStorage - so forgive me if I'm doing this wrong.

The visible problem is that calling create on a collection or save on a model will show up correctly in LocalStorage, but when refreshing a page, a call to collection.fetch does not populate the collection from the store. That is, we can write to local storage, but not read from it.

findAll has a vestigial call to a jsonData function - which was removed in favor of the serializer parameter. Since the data variable in findAll was declared twice, I was receiving "object has no method jsonData" errors when calling collection.fetch on a stored collection.
