### PR TITLE
Return boolean on update and create

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -83,7 +83,7 @@ extend(Backbone.LocalStorage.prototype, {
     this.localStorage().setItem(this.name+"-"+model.id, this.serializer.serialize(model));
     this.records.push(model.id.toString());
     this.save();
-    return this.find(model);
+    return this.find(model) !== false;
   },
 
   // Update a model by replacing its copy in `this.data`.
@@ -94,7 +94,7 @@ extend(Backbone.LocalStorage.prototype, {
       this.records.push(modelId);
       this.save();
     }
-    return this.find(model);
+    return this.find(model) !== false;
   },
 
   // Retrieve a model from `this.data` by id.


### PR DESCRIPTION
Return boolean on update and create to avoid backbone sync resetting each attribute. reference: https://github.com/jashkenas/backbone/blob/master/backbone.js#L509

Solution Caveats:
- String coercion will not be performed on save() as it is now so in memory models could vary from localStorage counterparts.

---

I came across this using the current implementation of Backbone.localStorage and Backbone-relational. I was listening to events on child relations in parent models, which of course were unattached during save() operations since the child relation attribute was being overwritten with the 'serverAttrs'.

I am submitting this pull request as a proof of issue/resolution, but the actual architectural improvement may be better solved in Backbone itself.
