### PR TITLE
Remove isNew check on store.destroy

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -115,8 +115,6 @@ extend(Backbone.LocalStorage.prototype, {
 
   // Delete a model from `this.data`, returning it.
   destroy: function(model) {
-    if (model.isNew())
-      return false
     this.localStorage().removeItem(this.name+"-"+model.id);
     var modelId = model.id.toString();
     for (var i = 0, id; i < this.records.length; i++) {


### PR DESCRIPTION
This line that checks `model.isNew()` causes and error when trying to store Backbone Collections. Collection objects do not have a `isNew` method so it fails when reaching this point. 

The check is unnecessary (it seems it wasn't [put in for a specific reason](https://github.com/jeromegn/Backbone.localStorage/commit/7a78c72e2f924bc69a1c98fee4c0e0763027fb07#diff-7b1029ce05077c56a6cc51f7a464902bL11) other than to skip the rest of the method if the model hasn't been saved). The official Backbone [implementation of sync](https://github.com/jashkenas/backbone/blob/master/backbone.js#L1192-L1250) doesn't have anything like this either.

If you'd rather keep it, we could put in something like `if (model.isNew !== undefined && model.isNew())` to ensure it doesn't fail with collections. 

Side note: this was hard for me to debug because the block that was calling `destroy` is incased in a [try-catch](https://github.com/jeromegn/Backbone.localStorage/blob/master/backbone.localStorage.js#L189-L194) that was swallowing the useful errors. Might be good to add a `console.error(errorMessage)` here
