### PR TITLE
allow more recent underscore versions to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "backbone": "~1.x.x",
-    "underscore": "~1.4.x"
+    "underscore": ">=1.4.0"
   },
   "devDependencies": {
     "uglify-js": "~1.2.6",


### PR DESCRIPTION
Currently uses a different Underscore in an app with a newer version, which is bad.
