### PR TITLE
Load 'underscore' to the factory

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -6,17 +6,17 @@
  */
 (function (root, factory) {
   if (typeof exports === 'object' && typeof require === 'function') {
-    module.exports = factory(require("backbone"));
+    module.exports = factory(require("backbone"), require('underscore'));
   } else if (typeof define === "function" && define.amd) {
     // AMD. Register as an anonymous module.
-    define(["backbone"], function(Backbone) {
+    define(["backbone", "underscore"], function(Backbone, _) {
       // Use global variables if the locals are undefined.
-      return factory(Backbone || root.Backbone);
+      return factory(Backbone || root.Backbone, _ || root._);
     });
   } else {
-    factory(Backbone);
+    factory(Backbone, _);
   }
-}(this, function(Backbone) {
+}(this, function(Backbone, _) {
 // A simple module to replace `Backbone.sync` with *localStorage*-based
 // persistence. Models are given GUIDS, and saved into a JSON object. Simple
 // as that.


### PR DESCRIPTION
`underscore` is used in [backbone.localStorage.js#L58](https://github.com/jeromegn/Backbone.localStorage/blob/master/backbone.localStorage.js#L58), but not loaded in the same way as `Backbone`, make it rely on the global object `_`.
