### PR TITLE
Ignoring unneeded files for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,5 +2,14 @@
   "name": "backbone.localStorage",
   "version": "1.1.9",
   "main": "./backbone.localStorage.js",
-  "dependencies": {}
+  "dependencies": {},
+  "ignore": [
+    "examples",
+    "spec",
+    "package.json",
+    ".documentup.json",
+    ".travis.yml"
+    "CNAME",
+    "Makefile"
+  ]
 }


### PR DESCRIPTION
Right now whenever you install the package with bower, it will fetch everything and that's not really needed. Aside from disk space being wasted (which is not much of a problem), there could be other side effects.

My use case is a project I'm working on. I added Karma to test the application and set RequireJS. I pointed Karma to fetch every JS file on the bower directory and then it failed with stuff like:

```
Backbone.localStorage in CommonJS environment
    ✖ encountered a declaration exception
      Chrome 35.0.1916 (Mac OS X 10.9.4)
    Error: Module name "../backbone.localStorage" has not been loaded yet for context: _. Use require([])
```

Or: `Chrome 35.0.1916 (Mac OS X 10.9.4) ERROR: 'There is no timestamp for /base/static/js/support/jquery.js!'`

Which I wasn't using. To fix this I had to add this to Karma:

`'static/libs/backbone.localStorage/spec/*.js'`

This changes to the bower file ensures no one will ever face this problem again.
