### PR TITLE
Mark package as compatible with Backbone 1.0.x and 1.1.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.1.13",
   "main": "./backbone.localStorage.js",
   "dependencies": {
-    "backbone": "~1.0.0"
+    "backbone": "^1 <1.2"
   },
   "ignore": [
     "examples",


### PR DESCRIPTION
I specifically didn't allow compatibility with backbone >= 1.2 because of the [maintainer's stance on versioning](https://gist.github.com/jashkenas/cbd2b088e20279ae2c8e)

Fixes #147.
