### PR TITLE
Use result (duplicated from _.result) to allow defining localStorage as a function

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -49,6 +49,12 @@ function extend(obj, props) {
   return obj;
 }
 
+function result(object, property) {
+    if (object == null) return void 0;
+    var value = object[property];
+    return (typeof value === 'function') ? object[property]() : value;
+}
+
 // Our Store is represented by a single JS object in *localStorage*. Create it
 // with a meaningful name, like the name you'd give a table.
 // window.Store is deprectated, use Backbone.LocalStorage instead
@@ -167,7 +173,7 @@ extend(Backbone.LocalStorage.prototype, {
 // *localStorage* property, which should be an instance of `Store`.
 // window.Store.sync and Backbone.localSync is deprecated, use Backbone.LocalStorage.sync instead
 Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(method, model, options) {
-  var store = model.localStorage || model.collection.localStorage;
+  var store = result(model, 'localStorage') || result(model.collection, 'localStorage');
 
   var resp, errorMessage;
   //If $ is having Deferred - use it.


### PR DESCRIPTION
Makes Backbone.localStorage behave similarly to Model urls.
