### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.1.13",
   "main": "./backbone.localStorage.js",
   "dependencies": {
-    "backbone": "~1.0.0"
+    "backbone": ">=1.0.0 <=1.1.2"
   },
   "ignore": [
     "examples",


### PR DESCRIPTION
Set Backbone between 1.0.0 and 1.1.2.
Prevents library conflict on Bower install (for example, in conjuction to Marionette.js)