### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+spec/
+examples/
+Makefile
+bower.json
+component.json
+CNAME


### PR DESCRIPTION
```
$ du -h backbone.localstorage-1.1.14.tgz
184K    backbone.localstorage-1.1.14.tgz
```

This PR strips from the npm package all but these files:

```
package.json
.npmignore
README.md
backbone.localStorage-min.js
backbone.localStorage.js
.documentup.json
.travis.yml
CHANGELOG.md
```

The package size drops down significantly.

```
$ du -h backbone.localstorage-1.1.14.tgz
16K backbone.localstorage-1.1.14.tgz
```

The stripped files are mostly tests and examples.

The decision of exactly what files should be included is somewhat arbitrary, but I think removing unnecessary parts is worth considering anyway.
