### PR TITLE
Fix Backbone version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.1.13",
   "main": "./backbone.localStorage.js",
   "dependencies": {
-    "backbone": "^1 <1.2"
+    "backbone": "~1.x.x"
   },
   "ignore": [
     "examples",


### PR DESCRIPTION
Current `bower.json` is causing conflict when used with others packages like Marionette, etc.

For more info about `bower.json` versions syntax, see the readme file in: [node-semver](https://github.com/npm/node-semver).