### PR TITLE
Added `ajaxSync` option support which will use the default Backbone.sync instead of localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ window.SomeCollection = Backbone.Collection.extend({
 });
 ```
 
-If needed, you can use default ajax sync by passing the `ajaxSync` option flag to any Backbone function which uses `Backbone.sync`, for example:
+If needed, you can use the default `Backbone.sync` (instead of local storage) by passing the `ajaxSync` option flag to any Backbone AJAX function, for example:
 
 ```javascript
 var myModel = new SomeModel();

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ window.SomeCollection = Backbone.Collection.extend({
 });
 ```
 
-If needed, you can use default ajax sync by passing the `ajaxSync` option flag:
+If needed, you can use default ajax sync by passing the `ajaxSync` option flag to any Backbone function which uses `Backbone.sync`, for example:
 
 ```javascript
-var myCollection = new SomeCollection();
-myCollection.fetch({ ajaxSync: true });
-myCollection.save({ new: "value" }, { ajaxSync: true });
+var myModel = new SomeModel();
+myModel.fetch({ ajaxSync: true });
+myModel.save({ new: "value" }, { ajaxSync: true });
 ```
 
 ### RequireJS

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ window.SomeCollection = Backbone.Collection.extend({
   
 });
 ```
+
+If needed, you can use default ajax sync by passing the `ajaxSync` option flag:
+
+```javascript
+var myCollection = new SomeCollection();
+myCollection.fetch({ ajaxSync: true });
+myCollection.save({ new: "value" }, { ajaxSync: true });
+```
+
 ### RequireJS
 
 Include [RequireJS](http://requirejs.org):

--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -238,8 +238,8 @@ Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(m
 
 Backbone.ajaxSync = Backbone.sync;
 
-Backbone.getSyncMethod = function(model) {
-  if(model.localStorage || (model.collection && model.collection.localStorage)) {
+Backbone.getSyncMethod = function(model, options) {
+  if(model.localStorage || (model.collection && model.collection.localStorage) && !options.ajaxSync) {
     return Backbone.localSync;
   }
 
@@ -249,7 +249,7 @@ Backbone.getSyncMethod = function(model) {
 // Override 'Backbone.sync' to default to localSync,
 // the original 'Backbone.sync' is still available in 'Backbone.ajaxSync'
 Backbone.sync = function(method, model, options) {
-  return Backbone.getSyncMethod(model).apply(this, [method, model, options]);
+  return Backbone.getSyncMethod(model, options).apply(this, [method, model, options]);
 };
 
 return Backbone.LocalStorage;

--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -239,7 +239,9 @@ Backbone.LocalStorage.sync = window.Store.sync = Backbone.localSync = function(m
 Backbone.ajaxSync = Backbone.sync;
 
 Backbone.getSyncMethod = function(model, options) {
-  if(model.localStorage || (model.collection && model.collection.localStorage) && !options.ajaxSync) {
+  var forceAjaxSync = options && options.ajaxSync;
+
+  if(!forceAjaxSync && (model.localStorage || (model.collection && model.collection.localStorage))) {
     return Backbone.localSync;
   }
 

--- a/spec/localStorage_spec.js
+++ b/spec/localStorage_spec.js
@@ -39,8 +39,16 @@ describe("Backbone.localStorage", function(){
       collection.fetch();
     });
 
-    it("should use `localSync`", function(){
+    it("should default to use `localSync`", function(){
       assert.equal(Backbone.getSyncMethod(collection), Backbone.localSync);
+    });
+
+    it("should use `ajaxSync` when option is passed", function(){
+      assert.equal(Backbone.getSyncMethod(collection, { ajaxSync: true }), Backbone.ajaxSync);
+    });
+
+    it("should use `localSync` when other options are passed", function(){
+      assert.equal(Backbone.getSyncMethod(collection, { ajaxSync: false, data: {}, silent: true }), Backbone.localSync);
     });
 
     it("should initially be empty", function(){
@@ -213,6 +221,14 @@ describe("Backbone.localStorage", function(){
       assert.equal(Backbone.getSyncMethod(model), Backbone.localSync);
     });
 
+    it("should use `ajaxSync` when option is passed", function(){
+      assert.equal(Backbone.getSyncMethod(model, { ajaxSync: true }), Backbone.ajaxSync);
+    });
+
+    it("should use `localSync` when other options are passed", function(){
+      assert.equal(Backbone.getSyncMethod(model, { ajaxSync: false, data: {}, silent: true }), Backbone.localSync);
+    });
+
     describe("fetch", function(){
       it('should fire sync event on fetch', function(done) {
         var model = new Model(attributes);
@@ -348,6 +364,7 @@ describe("Without Backbone.localStorage", function(){
 
     it("should use `ajaxSync`", function(){
       assert.equal(Backbone.getSyncMethod(collection), Backbone.ajaxSync);
+      assert.equal(Backbone.getSyncMethod(collection, { ajaxSync: false }), Backbone.ajaxSync);
     });
   });
 
@@ -357,6 +374,7 @@ describe("Without Backbone.localStorage", function(){
 
     it("should use `ajaxSync`", function(){
       assert.equal(Backbone.getSyncMethod(model), Backbone.ajaxSync);
+      assert.equal(Backbone.getSyncMethod(model, { ajaxSync: false }), Backbone.ajaxSync);
     });
   });
 


### PR DESCRIPTION
I had a need to go to the server for a particular request on a backbone object that was otherwise persisted to localStorage.  I thought an option flag would be an easy way to "toggle" between the two implementations of sync (default, and localStorage).