### PR TITLE
Add sessionStorage support

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -55,7 +55,12 @@ function result(object, property) {
 // Our Store is represented by a single JS object in *localStorage*. Create it
 // with a meaningful name, like the name you'd give a table.
 // window.Store is deprectated, use Backbone.LocalStorage instead
-Backbone.LocalStorage = window.Store = function(name, serializer) {
+Backbone.LocalStorage = window.Store = function(name, serializer, method) {
+  this.method = method || 'localStorage';
+  if( this.method !== 'localStorage' && this.method !== 'sessionStorage' ) {
+    throw "Backbone.localStorage: Method needs to be one of 'localStorage' or 'sessionStorage', not " + this.method
+  }
+
   if( !this.localStorage ) {
     throw "Backbone.localStorage: Environment does not support localStorage."
   }
@@ -134,7 +139,11 @@ extend(Backbone.LocalStorage.prototype, {
   },
 
   localStorage: function() {
-    return localStorage;
+    if (this.method === 'localStorage') {
+      return localStorage;
+    } else if (this.method === 'sessionStorage') {
+      return sessionStorage;
+    }
   },
 
   // Clear localStorage for specific collection.


### PR DESCRIPTION
This is a very simple addition to the `Backbone.localStorage` constructor function as well as the (very neat) `localStorage` method. It adds full sessionStorage support, since the APIs are interchangeable.

Because of the presence of the `localStorage` method I assumed this was supposed to happen at some point, although I'm not sure if this is the way you'd originally planned to implement it. It's entirely possible the original idea was to extend the `localStorage` class unto a `Backbone.sessionStorage` alternative and only change the method? It's also possible none of this was ever meant to happen of course...

I figured it'd be a neat addition.
