### PR TITLE
~1.x.x → ~1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "backbone.localStorage",
   "main": "./backbone.localStorage.js",
   "dependencies": {
-    "backbone": "~1.x.x"
+    "backbone": "~1"
   },
   "ignore": [
     "examples",


### PR DESCRIPTION
`~1.x.x` is valid but still usage of "x" is unnecessary.
