### PR TITLE
Fix typo

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -54,7 +54,7 @@ function result(object, property) {
 
 // Our Store is represented by a single JS object in *localStorage*. Create it
 // with a meaningful name, like the name you'd give a table.
-// window.Store is deprectated, use Backbone.LocalStorage instead
+// window.Store is deprecated, use Backbone.LocalStorage instead
 Backbone.LocalStorage = window.Store = function(name, serializer) {
   if( !this.localStorage ) {
     throw "Backbone.localStorage: Environment does not support localStorage."


### PR DESCRIPTION
Found a spelling mistake -
`deprectated` > `deprecated`