### PR TITLE
Model ID change (update) must remove old ID instance from localStorage

### DIFF
--- a/backbone.localStorage.js
+++ b/backbone.localStorage.js
@@ -97,9 +97,14 @@ extend(Backbone.LocalStorage.prototype, {
   update: function(model) {
     this.localStorage().setItem(this._itemName(model.id), this.serializer.serialize(model));
     var modelId = model.id.toString();
+    var modelPreviousId = model.previous(model.idAttribute);
     if (!contains(this.records, modelId)) {
       this.records.push(modelId);
       this.save();
+
+      if (modelPreviousId && modelId !== modelPreviousId.toString()) {
+        this.destroy({id: modelPreviousId});
+      }
     }
     return this.find(model);
   },

--- a/spec/localStorage_spec.js
+++ b/spec/localStorage_spec.js
@@ -267,6 +267,27 @@ describe("Backbone.localStorage", function(){
 
       });
 
+      describe("with new id", function(){
+        var oldId = 0;
+      
+        before(function(){
+          oldId = model.id;
+          var attr = {number: 42};
+          attr[model.idAttribute] = 9999;
+          model.save(attr);
+          model.fetch();
+        });
+
+        it("should persist the changes", function(){
+          assert.deepEqual(model.toJSON(), _.extend(_.clone(attributes), {id: model.id, number: 42}));
+        });
+
+        it("should have removed the old id instance from the store", function(){
+          assert.isNull(Model.prototype.localStorage.find({id:oldId}), "Model with old id is still in localStorage");
+        });
+
+      });
+
       describe('fires events', function(){
         before(function(){
           this.model = new Model();


### PR DESCRIPTION
Updating model ID currently creates new instance with new ID and leaves the old one unchanged. This fix destroys old instance.
